### PR TITLE
feat: expand notes with CRUD support

### DIFF
--- a/backend/src/routes/tasks.js
+++ b/backend/src/routes/tasks.js
@@ -1,0 +1,50 @@
+import { Router } from 'express';
+import { Task } from '../models/Task.js';
+import { computeQuadrant } from '../utils/quadrant.js';
+
+const router = Router();
+
+// list met filters: ?quadrant=II&habit=3&status=todo
+router.get('/', async (req, res) => {
+  const where = {};
+  ['quadrant','habit','status'].forEach(k => { if (req.query[k]) where[k] = req.query[k]; });
+  const tasks = await Task.findAll({ where, order: [['updated_at','DESC']] });
+  res.json(tasks);
+});
+
+// create
+router.post('/', async (req, res) => {
+  const body = req.body || {};
+  const quadrant = computeQuadrant(body);
+  const task = await Task.create({ ...body, quadrant });
+  res.status(201).json(task);
+});
+
+// update (recompute quadrant als velden wijzigen)
+router.patch('/:id', async (req, res) => {
+  const task = await Task.findByPk(req.params.id);
+  if (!task) return res.status(404).json({ error: 'Not found' });
+
+  const next = { ...task.toJSON(), ...req.body };
+  next.quadrant = computeQuadrant(next);
+
+  await task.update(next);
+  res.json(task);
+});
+
+// done/undone
+router.post('/:id/complete', async (req, res) => {
+  const task = await Task.findByPk(req.params.id);
+  if (!task) return res.status(404).json({ error: 'Not found' });
+  const done = !!req.body.done;
+  await task.update({ status: done ? 'done' : 'todo', completedAt: done ? new Date() : null });
+  res.json(task);
+});
+
+// delete
+router.delete('/:id', async (req, res) => {
+  const n = await Task.destroy({ where: { id: req.params.id }});
+  res.json({ deleted: n > 0 });
+});
+
+export default router;

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -15,6 +15,18 @@ export async function createNote(input: NoteBase): Promise<Note> {
   });
   return r.json();
 }
+export async function updateNote(id: number, patch: Partial<NoteBase>): Promise<Note> {
+  const r = await fetch(`${BASE}/api/notes/${id}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(patch),
+  });
+  return r.json();
+}
+export async function deleteNote(id: number): Promise<{ deleted: boolean }> {
+  const r = await fetch(`${BASE}/api/notes/${id}`, { method: 'DELETE' });
+  return r.json();
+}
 
 // TASKS
 export async function fetchTasks(params: Record<string, string> = {}): Promise<Task[]> {


### PR DESCRIPTION
## Summary
- add dedicated Notes API routes with list, create, update and delete
- move existing task endpoints to separate file
- expose note update/delete in client and wire note editor to backend

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `cd backend && npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_b_68b21d4491c08332bf00ae511e7063a4