### PR TITLE
Add onboarding flow and help page for new users

### DIFF
--- a/src/HelpPage.tsx
+++ b/src/HelpPage.tsx
@@ -1,0 +1,41 @@
+export default function HelpPage({ onRestartOnboarding }: { onRestartOnboarding: () => void }) {
+  return (
+    <div className="p-8">
+      <section className="max-w-3xl mx-auto rounded-2xl backdrop-blur-xl bg-white/5 border border-white/10 p-8 shadow-lg">
+        <h1 className="text-2xl font-semibold mb-4">Help & Uitleg</h1>
+        <p className="text-slate-300 mb-4">
+          HabitFlow helpt je de 7 Habits toe te passen in je dagelijkse planning. Hieronder vind je een korte uitleg.
+        </p>
+        <h2 className="text-xl font-semibold mt-6 mb-2">Notities</h2>
+        <p className="text-slate-300 mb-4">
+          Maak notities per habit, voeg tags toe en houd je voortgang bij. Gebruik de templates voor een snelle start.
+        </p>
+        <h2 className="text-xl font-semibold mt-6 mb-2">Task matrix</h2>
+        <p className="text-slate-300 mb-4">
+          Orden je taken volgens de Eisenhower-matrix. Focus op de quadranten die echt impact hebben.
+        </p>
+        <div className="flex flex-col items-start gap-4">
+          <button
+            onClick={onRestartOnboarding}
+            className="px-4 py-2 rounded-xl bg-teal-500/20 hover:bg-teal-500/30 border border-teal-300/30"
+          >
+            Onboarding opnieuw starten
+          </button>
+          <p className="text-slate-400 text-sm">
+            Deze app werd gemaakt door{' '}
+            <a
+              href="https://www.xinudesign.be"
+              className="underline"
+              target="_blank"
+              rel="noreferrer"
+            >
+              Xinudesign
+            </a>
+            .
+          </p>
+          <p className="text-slate-300">Heb je vragen of feedback? Laat het ons weten!</p>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/Onboarding.tsx
+++ b/src/Onboarding.tsx
@@ -1,0 +1,62 @@
+import { useState } from 'react';
+import { FiArrowRight, FiArrowLeft, FiCheck } from 'react-icons/fi';
+
+export default function Onboarding({ onFinish }: { onFinish: () => void }) {
+  const steps = [
+    {
+      title: 'Welkom bij HabitFlow',
+      body: 'Beheer je taken en notities volgens de 7 Habits. Laten we kort de belangrijkste onderdelen bekijken.'
+    },
+    {
+      title: 'Notities maken',
+      body: 'Leg je ideeën vast en organiseer ze per habit. Gebruik tags om alles snel terug te vinden.'
+    },
+    {
+      title: 'Task matrix',
+      body: 'Plan je dag met de Eisenhower-matrix en houd focus op wat er echt toe doet.'
+    }
+  ];
+  const [index, setIndex] = useState(0);
+
+  const next = () => {
+    if (index < steps.length - 1) {
+      setIndex(index + 1);
+    } else {
+      localStorage.setItem('hf.onboarded', '1');
+      onFinish();
+    }
+  };
+  const prev = () => setIndex(Math.max(index - 1, 0));
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur">
+      <div className="rounded-2xl bg-slate-900/90 border border-white/10 p-8 w-[min(90vw,400px)] text-center">
+        <h2 className="text-xl font-semibold mb-4">{steps[index].title}</h2>
+        <p className="text-slate-300 mb-6">{steps[index].body}</p>
+        <div className="flex items-center justify-between">
+          <button
+            onClick={prev}
+            disabled={index === 0}
+            className="flex items-center gap-1 px-4 py-2 rounded-xl bg-white/10 border border-white/15 disabled:opacity-30"
+          >
+            <FiArrowLeft /> Vorige
+          </button>
+          <button
+            onClick={next}
+            className="flex items-center gap-1 px-4 py-2 rounded-xl bg-teal-500/20 hover:bg-teal-500/30 border border-teal-300/30"
+          >
+            {index < steps.length - 1 ? (
+              <>
+                Volgende <FiArrowRight />
+              </>
+            ) : (
+              <>
+                Afronden <FiCheck />
+              </>
+            )}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/TeslaLayout.tsx
+++ b/src/TeslaLayout.tsx
@@ -1,15 +1,18 @@
 import { useState } from 'react';
-import { FiHome, FiCalendar, FiFileText, FiUser, FiSettings } from 'react-icons/fi';
+import { FiHome, FiCalendar, FiFileText, FiUser, FiSettings, FiHelpCircle } from 'react-icons/fi';
 import StartScreen from './StartScreen';
 import TaskMatrix from './TaskMatrix';
 import App from './App';
 import HomePage from './HomePage';
+import Onboarding from './Onboarding';
+import HelpPage from './HelpPage';
 
 const cls = (...xs: Array<string | false | undefined>) => xs.filter(Boolean).join(' ');
 
 export default function TeslaLayout() {
   const [started, setStarted] = useState(false);
-  const [active, setActive] = useState<'home' | 'tasks' | 'notes' | 'profile'>('home');
+  const [active, setActive] = useState<'home' | 'tasks' | 'notes' | 'profile' | 'help'>('home');
+  const [showOnboarding, setShowOnboarding] = useState(() => !localStorage.getItem('hf.onboarded'));
 
   if (!started) {
     return <StartScreen onStart={() => setStarted(true)} />;
@@ -59,6 +62,17 @@ export default function TeslaLayout() {
             <button
               className={cls(
                 'p-3 rounded-xl transition',
+                active === 'help' ? 'bg-white/20 text-teal-300' : 'bg-white/5 hover:bg-white/10'
+              )}
+              onClick={() => setActive('help')}
+            >
+              <FiHelpCircle />
+            </button>
+          </li>
+          <li>
+            <button
+              className={cls(
+                'p-3 rounded-xl transition',
                 active === 'profile' ? 'bg-white/20 text-teal-300' : 'bg-white/5 hover:bg-white/10'
               )}
               onClick={() => setActive('profile')}
@@ -85,6 +99,14 @@ export default function TeslaLayout() {
         {active === 'home' && <HomePage onSelect={setActive} />}
         {active === 'tasks' && <TaskMatrix />}
         {active === 'notes' && <App />}
+        {active === 'help' && (
+          <HelpPage
+            onRestartOnboarding={() => {
+              localStorage.removeItem('hf.onboarded');
+              setShowOnboarding(true);
+            }}
+          />
+        )}
         {active === 'profile' && (
           <div className="p-8">
             <section className="max-w-3xl mx-auto rounded-2xl backdrop-blur-xl bg-white/5 border border-white/10 p-8 shadow-lg">
@@ -94,6 +116,7 @@ export default function TeslaLayout() {
           </div>
         )}
       </main>
+      {showOnboarding && <Onboarding onFinish={() => setShowOnboarding(false)} />}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Introduce step-by-step onboarding overlay stored in localStorage
- Add dedicated help page with restart option and Xinudesign attribution
- Wire onboarding and help into main layout navigation, allowing onboarding to be relaunched

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b221b78864833297434ae84b7adb50