### PR TITLE
Fix dropdown layout and item overflow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -437,7 +437,7 @@ export default function App() {
           <aside className="lg:col-span-3 rounded-2xl p-3 backdrop-blur-xl bg-white/5 border border-white/10 mb-4 lg:mb-0 flex flex-col min-h-0">
             <div className="grid grid-cols-2 gap-2">
               <select
-                className="px-3 py-2 rounded-xl bg-white/10 border border-white/10 text-sm"
+                className="px-3 py-2 w-full rounded-xl bg-white/10 border border-white/10 text-sm"
                 value={habit}
                 onChange={(e) => {
                   const val = e.target.value;
@@ -450,7 +450,7 @@ export default function App() {
                 ))}
               </select>
               <select
-                className="px-3 py-2 rounded-xl bg-white/10 border border-white/10 text-sm"
+                className="px-3 py-2 w-full rounded-xl bg-white/10 border border-white/10 text-sm"
                 value={quad}
                 onChange={(e) => setQuad(e.target.value as Quadrant | "all")}
               >
@@ -531,14 +531,14 @@ export default function App() {
             ) : (
               <>
                 {/* Editor topbar */}
-                <div className="p-3 border-b border-white/10 flex items-center gap-2">
+                <div className="p-3 border-b border-white/10 flex flex-wrap items-center gap-2">
                   <input
-                    className="flex-1 px-3 py-2 rounded-xl bg-white/10 border border-white/10 text-sm"
+                    className="flex-1 min-w-full sm:min-w-0 px-3 py-2 rounded-xl bg-white/10 border border-white/10 text-sm"
                     value={current.title}
                     onChange={(e) => update({ title: e.target.value })}
                   />
                   <select
-                    className="px-3 py-2 rounded-xl bg-white/10 border border-white/10 text-sm"
+                    className="px-3 py-2 w-full sm:w-auto rounded-xl bg-white/10 border border-white/10 text-sm"
                     value={current.habit ?? 3}
                     onChange={(e) => update({ habit: Number(e.target.value) as HabitId })}
                   >
@@ -547,7 +547,7 @@ export default function App() {
                     ))}
                   </select>
                   <select
-                    className="px-3 py-2 rounded-xl bg-white/10 border border-white/10 text-sm"
+                    className="px-3 py-2 w-full sm:w-auto rounded-xl bg-white/10 border border-white/10 text-sm"
                     value={current.quadrant ?? "II"}
                     onChange={(e) => update({ quadrant: e.target.value as Quadrant })}
                   >

--- a/src/CreateTaskModal.tsx
+++ b/src/CreateTaskModal.tsx
@@ -60,7 +60,7 @@ export default function CreateTaskModal(
                     value={description} onChange={e=>setDescription(e.target.value)} />
 
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <select className="px-3 py-2 rounded-lg bg-white/10 border border-white/15"
+            <select className="px-3 py-2 w-full rounded-lg bg-white/10 border border-white/15"
                     value={habit === '' ? '' : habit}
                     onChange={e=> setHabit(e.target.value === '' ? '' : Number(e.target.value) as HabitId)}>
               <option value="">Habit (optioneel)</option>

--- a/src/TaskMatrix.tsx
+++ b/src/TaskMatrix.tsx
@@ -55,13 +55,13 @@ export default function TaskMatrix() {
   return (
     <div className="max-w-6xl mx-auto px-4 py-4">
       <div className="mb-3 flex flex-wrap items-center gap-2">
-        <select className="px-3 py-2 rounded-xl bg-white/10 border border-white/10 text-sm"
+        <select className="px-3 py-2 w-full sm:w-auto rounded-xl bg-white/10 border border-white/10 text-sm"
                 value={habit} onChange={e=> setHabit(e.target.value==='all' ? 'all' : Number(e.target.value) as HabitId)}>
           <option value="all">Alle Habits</option>
           {HABITS.map(h=> <option key={h} value={h}>H{h}</option>)}
         </select>
 
-        <select className="px-3 py-2 rounded-xl bg-white/10 border border-white/10 text-sm"
+        <select className="px-3 py-2 w-full sm:w-auto rounded-xl bg-white/10 border border-white/10 text-sm"
                 value={status} onChange={e=> setStatus(e.target.value as TaskStatus | 'all')}>
           {(['all', ...STATUSES] as const).map(s=> <option key={s} value={s}>{s}</option>)}
         </select>
@@ -100,13 +100,13 @@ function QuadrantCol(
         {tasks.map(t => (
           <article key={t.id} className="p-3 rounded-xl bg-white/5 border border-white/10">
             <div className="flex items-start justify-between gap-2">
-              <div className="flex items-center gap-2">
+              <div className="flex items-center gap-2 min-w-0">
                 <button onClick={()=>onToggle(t)} className="text-teal-300">
                   {t.status === 'done' ? <FiCheckSquare/> : <FiSquare/>}
                 </button>
-                <div>
-                  <div className="font-medium">{t.title}</div>
-                  {t.description && <div className="text-xs text-slate-400">{t.description}</div>}
+                <div className="min-w-0">
+                  <div className="font-medium break-words">{t.title}</div>
+                  {t.description && <div className="text-xs text-slate-400 break-words">{t.description}</div>}
                   <div className="text-[11px] text-slate-400 mt-1 flex items-center gap-2">
                     <span>H{t.habit ?? '-'}</span>
                     {t.dueAt && <span className="inline-flex items-center gap-1"><FiClock/>{new Date(t.dueAt).toLocaleString()}</span>}
@@ -116,7 +116,7 @@ function QuadrantCol(
                 </div>
               </div>
 
-              <div className="flex gap-1">
+              <div className="flex gap-1 flex-wrap">
                 {(['I','II','III','IV'] as Quadrant[]).map(q =>
                   <button key={q} onClick={()=>onQuickMove(t, q)}
                     className="px-2 py-1 text-xs rounded-lg bg-white/10 border border-white/10 hover:bg-white/20">→ {q}</button>


### PR DESCRIPTION
## Summary
- make dropdown menus full width and responsive across views
- wrap task controls and break long text to prevent overflow

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b22924c3d48332859ef1ba7d7dc2e3