### PR TITLE
Add planner view with day/week/month layouts

### DIFF
--- a/src/HomePage.tsx
+++ b/src/HomePage.tsx
@@ -1,7 +1,7 @@
-import { FiCalendar, FiFileText, FiArrowRight } from 'react-icons/fi';
+import { FiCalendar, FiFileText, FiArrowRight, FiGrid } from 'react-icons/fi';
 import { Sparkles } from 'lucide-react';
 
-export default function HomePage({ onSelect }: { onSelect: (view: 'tasks' | 'notes') => void }) {
+export default function HomePage({ onSelect }: { onSelect: (view: 'tasks' | 'planner' | 'notes') => void }) {
   return (
     <div className="p-8">
       <section className="max-w-3xl mx-auto rounded-2xl backdrop-blur-xl bg-white/5 border border-white/10 p-8 shadow-lg">
@@ -9,12 +9,19 @@ export default function HomePage({ onSelect }: { onSelect: (view: 'tasks' | 'not
         <p className="text-slate-300 mb-6 flex items-center gap-2">
           <Sparkles className="text-teal-300" size={16} /> Klaar om productief te zijn?
         </p>
-        <div className="grid sm:grid-cols-2 gap-4">
+        <div className="grid sm:grid-cols-3 gap-4">
           <button
             onClick={() => onSelect('tasks')}
             className="group flex items-center justify-between rounded-xl px-4 py-3 bg-white/10 hover:bg-white/20 border border-white/15 transition"
           >
-            <span className="inline-flex items-center gap-2"><FiCalendar /> Task matrix</span>
+            <span className="inline-flex items-center gap-2"><FiGrid /> Task matrix</span>
+            <FiArrowRight className="opacity-0 group-hover:opacity-100 group-hover:translate-x-1 transition" />
+          </button>
+          <button
+            onClick={() => onSelect('planner')}
+            className="group flex items-center justify-between rounded-xl px-4 py-3 bg-white/10 hover:bg-white/20 border border-white/15 transition"
+          >
+            <span className="inline-flex items-center gap-2"><FiCalendar /> Planner</span>
             <FiArrowRight className="opacity-0 group-hover:opacity-100 group-hover:translate-x-1 transition" />
           </button>
           <button

--- a/src/Planner.tsx
+++ b/src/Planner.tsx
@@ -1,0 +1,120 @@
+import { useState } from 'react';
+
+const cls = (...xs: Array<string | false | undefined>) => xs.filter(Boolean).join(' ');
+
+function DayView() {
+  const hours = Array.from({ length: 17 }, (_, i) => i + 6); // 06:00-22:00
+  return (
+    <div className="grid grid-cols-[60px_1fr] gap-x-4 text-sm">
+      {hours.map((h) => (
+        <div key={h} className="contents">
+          <div className="text-right pr-2 text-slate-400">{String(h).padStart(2, '0')}:00</div>
+          <div className="border-b border-slate-700 h-12" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function WeekView() {
+  const days = ['Ma', 'Di', 'Wo', 'Do', 'Vr', 'Za', 'Zo'];
+  const hours = Array.from({ length: 17 }, (_, i) => i + 6);
+  return (
+    <div className="grid grid-cols-[60px_repeat(7,1fr)] text-sm">
+      <div />
+      {days.map((d) => (
+        <div key={d} className="text-center font-medium py-2 border-l border-slate-700">
+          {d}
+        </div>
+      ))}
+      {hours.map((h) => (
+        <div key={h} className="contents">
+          <div className="text-right pr-2 text-slate-400 border-t border-slate-700">
+            {String(h).padStart(2, '0')}:00
+          </div>
+          {days.map((d) => (
+            <div key={d} className="border-l border-t border-slate-700 h-12" />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function MonthView() {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = now.getMonth();
+  const first = new Date(year, month, 1);
+  const start = (first.getDay() + 6) % 7; // maandag = 0
+  const cells = Array.from({ length: 42 }, (_, i) => {
+    const date = new Date(year, month, i - start + 1);
+    return { date, current: date.getMonth() === month };
+  });
+  const weekDays = ['Ma', 'Di', 'Wo', 'Do', 'Vr', 'Za', 'Zo'];
+  return (
+    <div className="grid grid-cols-7 text-sm">
+      {weekDays.map((d) => (
+        <div key={d} className="text-center font-medium py-2 border-b border-slate-700">
+          {d}
+        </div>
+      ))}
+      {cells.map((c, i) => (
+        <div
+          key={i}
+          className={cls(
+            'h-24 border-b border-r border-slate-700 p-1',
+            c.current ? '' : 'bg-white/5 text-slate-500'
+          )}
+        >
+          <div className="text-right text-xs">{c.date.getDate()}</div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default function Planner() {
+  const [view, setView] = useState<'day' | 'week' | 'month'>('day');
+  return (
+    <div className="p-8">
+      <section className="max-w-5xl mx-auto rounded-2xl backdrop-blur-xl bg-white/5 border border-white/10 p-8 shadow-lg">
+        <div className="mb-4 flex gap-2">
+          <button
+            className={cls(
+              'px-4 py-2 rounded-lg text-sm transition',
+              view === 'day' ? 'bg-white/20 text-teal-300' : 'bg-white/10 hover:bg-white/15'
+            )}
+            onClick={() => setView('day')}
+          >
+            Dag
+          </button>
+          <button
+            className={cls(
+              'px-4 py-2 rounded-lg text-sm transition',
+              view === 'week' ? 'bg-white/20 text-teal-300' : 'bg-white/10 hover:bg-white/15'
+            )}
+            onClick={() => setView('week')}
+          >
+            Week
+          </button>
+          <button
+            className={cls(
+              'px-4 py-2 rounded-lg text-sm transition',
+              view === 'month' ? 'bg-white/20 text-teal-300' : 'bg-white/10 hover:bg-white/15'
+            )}
+            onClick={() => setView('month')}
+          >
+            Maand
+          </button>
+        </div>
+        <div className="overflow-auto">
+          {view === 'day' && <DayView />}
+          {view === 'week' && <WeekView />}
+          {view === 'month' && <MonthView />}
+        </div>
+      </section>
+    </div>
+  );
+}
+

--- a/src/TeslaLayout.tsx
+++ b/src/TeslaLayout.tsx
@@ -1,7 +1,16 @@
 import { useState } from 'react';
-import { FiHome, FiCalendar, FiFileText, FiUser, FiSettings, FiHelpCircle } from 'react-icons/fi';
+import {
+  FiHome,
+  FiCalendar,
+  FiFileText,
+  FiUser,
+  FiSettings,
+  FiHelpCircle,
+  FiGrid,
+} from 'react-icons/fi';
 import StartScreen from './StartScreen';
 import TaskMatrix from './TaskMatrix';
+import Planner from './Planner';
 import App from './App';
 import HomePage from './HomePage';
 import Onboarding from './Onboarding';
@@ -11,7 +20,9 @@ const cls = (...xs: Array<string | false | undefined>) => xs.filter(Boolean).joi
 
 export default function TeslaLayout() {
   const [started, setStarted] = useState(false);
-  const [active, setActive] = useState<'home' | 'tasks' | 'notes' | 'profile' | 'help'>('home');
+  const [active, setActive] = useState<
+    'home' | 'tasks' | 'planner' | 'notes' | 'profile' | 'help'
+  >('home');
   const [showOnboarding, setShowOnboarding] = useState(() => !localStorage.getItem('hf.onboarded'));
 
   if (!started) {
@@ -43,6 +54,17 @@ export default function TeslaLayout() {
                 active === 'tasks' ? 'bg-white/20 text-teal-300' : 'bg-white/5 hover:bg-white/10'
               )}
               onClick={() => setActive('tasks')}
+            >
+              <FiGrid />
+            </button>
+          </li>
+          <li>
+            <button
+              className={cls(
+                'p-3 rounded-xl transition',
+                active === 'planner' ? 'bg-white/20 text-teal-300' : 'bg-white/5 hover:bg-white/10'
+              )}
+              onClick={() => setActive('planner')}
             >
               <FiCalendar />
             </button>
@@ -98,6 +120,7 @@ export default function TeslaLayout() {
         />
         {active === 'home' && <HomePage onSelect={setActive} />}
         {active === 'tasks' && <TaskMatrix />}
+        {active === 'planner' && <Planner />}
         {active === 'notes' && <App />}
 
         {active === 'help' && (


### PR DESCRIPTION
## Summary
- add planner component with day, week, and month views
- integrate planner into navigation and home screen

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68b22b012f608332ae982167365d2937