### PR TITLE
Add AI note summarization and task classification

### DIFF
--- a/src/CreateTaskModal.tsx
+++ b/src/CreateTaskModal.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import type { HabitId, Quadrant, Task } from './types';
 import { createTask } from './services/api';
+import { aiClassify } from './services/ai';
 
 const HABITS: HabitId[] = [1,2,3,4,5,6,7];
 const QUICK: Record<Quadrant,{importance:number;urgency:number}> = {
@@ -42,6 +43,20 @@ export default function CreateTaskModal(
     onCreated(created);
     onClose();
     setTitle(''); setDescription(''); setHabit(''); setImportance(5); setUrgency(2); setDueAt(''); setTags('');
+  }
+
+  async function classify() {
+    const text = `${title}\n${description}`.trim();
+    if (!text) return;
+    try {
+      const c = await aiClassify(text);
+      if (c.habit) setHabit(c.habit);
+      if (c.quadrant) applyQuick(c.quadrant);
+      if (c.suggestedTags.length)
+        setTags(c.suggestedTags.join(', '));
+    } catch (err) {
+      console.error('AI classificatie mislukt', err);
+    }
   }
 
   function applyQuick(q: Quadrant) {
@@ -93,6 +108,10 @@ export default function CreateTaskModal(
                 Quick {q}
               </button>
             )}
+            <button onClick={classify}
+              className="px-2 py-1 rounded-lg bg-teal-400/20 border border-teal-300/30 text-teal-200">
+              AI suggesties
+            </button>
           </div>
 
           <input className="px-3 py-2 rounded-lg bg-white/10 border border-white/15"


### PR DESCRIPTION
## Summary
- integrate AI summarization and tagging when creating notes
- add AI-assisted classification for task creation

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `cd backend && npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68b42fb25f808332814e8ed37ddba590