### PR TITLE
Add AI note search and improve planner calendar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@
 .env.development
 .env.production
 backend/.env
-backend/.env
+node_modules/
+backend/node_modules/

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,6 +35,7 @@ import {
   updateNote as apiUpdateNote,
   deleteNote as apiDeleteNote,
 } from "./services/api";
+import { aiSearch } from "./services/ai";
 import type { Note, HabitId, Quadrant } from "./types";
 
 const HABITS: { id: HabitId; name: string }[] = [
@@ -344,6 +345,26 @@ export default function App() {
       });
   }
 
+  async function runAiSearch() {
+    const text = q.trim();
+    if (!text) return;
+    try {
+      const results = await aiSearch(text);
+      if (results.length) {
+        setSelected(results[0].id);
+        alert(
+          results
+            .map((r) => `${r.title} (${Math.round(r.score * 100)}%)`)
+            .join("\n")
+        );
+      } else {
+        alert("Geen resultaten");
+      }
+    } catch (err) {
+      console.error("AI zoek mislukt", err);
+    }
+  }
+
   return (
     <div className="h-full w-full overflow-hidden relative">
       {/* Background */}
@@ -406,6 +427,13 @@ export default function App() {
                     className="pl-9 pr-3 py-2 w-full sm:w-64 rounded-xl bg-white/10 border border-white/10 text-sm placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-teal-400/40"
                   />
                 </div>
+
+                <button
+                  onClick={runAiSearch}
+                  className="px-3 py-2 rounded-xl bg-teal-400/20 hover:bg-teal-400/30 border border-teal-300/30 text-teal-200 text-sm"
+                >
+                  AI zoek
+                </button>
 
                 <button
                   className="px-3 py-2 w-full sm:w-auto rounded-xl bg-teal-400/20 hover:bg-teal-400/30 border border-teal-300/30 text-teal-200 text-sm flex items-center gap-2"

--- a/src/CreateTaskModal.tsx
+++ b/src/CreateTaskModal.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import type { HabitId, Quadrant, Task } from './types';
 import { createTask } from './services/api';
+import { aiClassify } from './services/ai';
 
 const HABITS: HabitId[] = [1,2,3,4,5,6,7];
 const QUICK: Record<Quadrant,{importance:number;urgency:number}> = {
@@ -42,6 +43,20 @@ export default function CreateTaskModal(
     onCreated(created);
     onClose();
     setTitle(''); setDescription(''); setHabit(''); setImportance(5); setUrgency(2); setDueAt(''); setTags('');
+  }
+
+  async function classify() {
+    const text = `${title}\n${description}`.trim();
+    if (!text) return;
+    try {
+      const c = await aiClassify(text);
+      if (c.habit) setHabit(c.habit);
+      if (c.quadrant) applyQuick(c.quadrant);
+      if (c.suggestedTags.length)
+        setTags(c.suggestedTags.join(', '));
+    } catch (err) {
+      console.error('AI classificatie mislukt', err);
+    }
   }
 
   function applyQuick(q: Quadrant) {
@@ -93,6 +108,10 @@ export default function CreateTaskModal(
                 Quick {q}
               </button>
             )}
+            <button onClick={classify}
+              className="px-2 py-1 rounded-lg bg-teal-400/20 border border-teal-300/30 text-teal-200">
+              AI suggesties
+            </button>
           </div>
 
           <input className="px-3 py-2 rounded-lg bg-white/10 border border-white/15"

--- a/src/Planner.tsx
+++ b/src/Planner.tsx
@@ -51,11 +51,25 @@ function WeekView({ onSelect }: { onSelect: (date: Date, e: React.MouseEvent) =>
   return (
     <div className="grid grid-cols-[60px_repeat(7,1fr)] text-sm">
       <div />
-      {days.map((d) => (
-        <div key={d} className="text-center font-medium py-2 border-l border-slate-700">
-          {d}
-        </div>
-      ))}
+      {days.map((d, i) => {
+        const date = new Date(monday);
+        date.setDate(monday.getDate() + i);
+        const isToday =
+          date.getDate() === now.getDate() &&
+          date.getMonth() === now.getMonth() &&
+          date.getFullYear() === now.getFullYear();
+        return (
+          <div
+            key={d}
+            className={cls(
+              'text-center font-medium py-2 border-l border-slate-700',
+              isToday && 'bg-teal-500/20 text-teal-200'
+            )}
+          >
+            {d} {date.getDate()}/{date.getMonth() + 1}
+          </div>
+        );
+      })}
       {hours.map((h) => (
         <div key={h} className="contents">
           <div className="text-right pr-2 text-slate-400 border-t border-slate-700">
@@ -101,20 +115,25 @@ function MonthView({ onSelect }: { onSelect: (date: Date, e: React.MouseEvent) =
           {d}
         </div>
       ))}
-      {cells.map((c, i) => (
-        <div
-          key={i}
-          className={cls(
-
-            'h-24 border-b border-r border-slate-700 p-1 cursor-pointer',
-            c.current ? '' : 'bg-white/5 text-slate-500'
-          )}
-          onClick={(e) => onSelect(new Date(c.date), e)}
-
-        >
-          <div className="text-right text-xs">{c.date.getDate()}</div>
-        </div>
-      ))}
+      {cells.map((c, i) => {
+        const isToday =
+          c.date.getDate() === now.getDate() &&
+          c.date.getMonth() === now.getMonth() &&
+          c.date.getFullYear() === now.getFullYear();
+        return (
+          <div
+            key={i}
+            className={cls(
+              'h-24 border-b border-r border-slate-700 p-1 cursor-pointer',
+              c.current ? '' : 'bg-white/5 text-slate-500',
+              isToday && 'bg-teal-500/20 text-teal-200'
+            )}
+            onClick={(e) => onSelect(new Date(c.date), e)}
+          >
+            <div className="text-right text-xs">{c.date.getDate()}</div>
+          </div>
+        );
+      })}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- integrate AI summarization and tagging when creating notes
- add AI-assisted classification for task creation
- enable AI-powered note search and highlight current date in planner views
- ignore node_modules directories

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `cd backend && npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68b42fb25f808332814e8ed37ddba590