### PR TITLE
feat: add reusable onboarding and helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ HabitFlow is een **React + TypeScript** app (Vite) met een **Tesla-2025 look**: 
 
 ## ✨ Features
 
-- **Notities**: eenvoudige editor (markdown-friendly), auto-save, zoeken, tags. d
+- **Notities**: eenvoudige editor (markdown-friendly), auto-save, zoeken, tags.
 - **AI-integratie**:
   - Detecteert **acties** in vrije tekst.
   - Classificeert in **Habit (1–7)** en **Quadrant (I–IV)**.
@@ -15,6 +15,8 @@ HabitFlow is een **React + TypeScript** app (Vite) met een **Tesla-2025 look**: 
   - **Maand**: kalenderoverzicht.
   - Drag-and-drop tussen views (optioneel via dnd-kit).
 - **Matrix**: visuele Eisenhower-matrix met hover-interacties.
+- **Missie & Waarden**: noteer je persoonlijke missie en kernwaarden met duidelijke hints.
+- **Onboarding & Help**: interactieve gids voor nieuwe gebruikers, altijd opnieuw te starten.
 - **Vlaams taalgebruik**: “Takenlijst”, “Weekplanner”, “Herinnering”.
 - **Design**: Dark mode standaard, glass cards, subtiele vonken/aurora-achtergronden.
 
@@ -32,3 +34,10 @@ HabitFlow is een **React + TypeScript** app (Vite) met een **Tesla-2025 look**: 
 git clone https://github.com/MichaelRedant/HabitFlow.git
 cd HabitFlow
 npm install
+```
+
+### 2) Start development server
+
+```bash
+npm run dev
+```

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,34 +6,49 @@ import DailyPage from './components/DailyPage';
 import Notes from './components/Notes';
 import SharpenSaw from './components/SharpenSaw';
 import Reflection from './components/Reflection';
+import HelpPage from './HelpPage';
+import Onboarding from './Onboarding';
 
 export default function App() {
-  const [page, setPage] = useState<'planner' | 'daily' | 'compass' | 'notes' | 'renewal' | 'reflection'>('planner');
+  const [page, setPage] = useState<
+    'planner' | 'daily' | 'compass' | 'notes' | 'renewal' | 'reflection' | 'help'
+  >('planner');
+  const [showOnboarding, setShowOnboarding] = useState(
+    () => !localStorage.getItem('hf.onboarded')
+  );
+
+  const restartOnboarding = () => {
+    localStorage.removeItem('hf.onboarded');
+    setShowOnboarding(true);
+  };
 
   return (
-
-    <div className="flex h-screen bg-gradient-to-br from-gray-900 via-blue-900 to-gray-900 text-gray-100">
-      <aside className="w-64 border-r border-gray-700 p-4 overflow-y-auto backdrop-blur" aria-label="zijbalk">
-        <MissionValues />
-        <nav className="mt-4 space-y-1">
-          <NavButton label="Weekplanner" active={page === 'planner'} onClick={() => setPage('planner')} />
-          <NavButton label="Dag" active={page === 'daily'} onClick={() => setPage('daily')} />
-          <NavButton label="Weekkompas" active={page === 'compass'} onClick={() => setPage('compass')} />
-          <NavButton label="Notities" active={page === 'notes'} onClick={() => setPage('notes')} />
-          <NavButton label="Zaag Scherpen" active={page === 'renewal'} onClick={() => setPage('renewal')} />
-          <NavButton label="Reflectie" active={page === 'reflection'} onClick={() => setPage('reflection')} />
-        </nav>
-      </aside>
-      <main className="flex-1 overflow-y-auto p-4 animate-fade-in" aria-label="hoofdinhoud">
-
-        {page === 'planner' && <WeeklyPlanner />}
-        {page === 'daily' && <DailyPage />}
-        {page === 'compass' && <RolesGoals />}
-        {page === 'notes' && <Notes />}
-        {page === 'renewal' && <SharpenSaw />}
-        {page === 'reflection' && <Reflection />}
-      </main>
-    </div>
+    <>
+      {showOnboarding && <Onboarding onFinish={() => setShowOnboarding(false)} />}
+      <div className="flex h-screen bg-gradient-to-br from-gray-900 via-blue-900 to-gray-900 text-gray-100">
+        <aside className="w-64 border-r border-gray-700 p-4 overflow-y-auto backdrop-blur" aria-label="zijbalk">
+          <MissionValues />
+          <nav className="mt-4 space-y-1">
+            <NavButton label="Weekplanner" active={page === 'planner'} onClick={() => setPage('planner')} />
+            <NavButton label="Dag" active={page === 'daily'} onClick={() => setPage('daily')} />
+            <NavButton label="Weekkompas" active={page === 'compass'} onClick={() => setPage('compass')} />
+            <NavButton label="Notities" active={page === 'notes'} onClick={() => setPage('notes')} />
+            <NavButton label="Zaag Scherpen" active={page === 'renewal'} onClick={() => setPage('renewal')} />
+            <NavButton label="Reflectie" active={page === 'reflection'} onClick={() => setPage('reflection')} />
+            <NavButton label="Help" active={page === 'help'} onClick={() => setPage('help')} />
+          </nav>
+        </aside>
+        <main className="flex-1 overflow-y-auto p-4 animate-fade-in" aria-label="hoofdinhoud">
+          {page === 'planner' && <WeeklyPlanner />}
+          {page === 'daily' && <DailyPage />}
+          {page === 'compass' && <RolesGoals />}
+          {page === 'notes' && <Notes />}
+          {page === 'renewal' && <SharpenSaw />}
+          {page === 'reflection' && <Reflection />}
+          {page === 'help' && <HelpPage onRestartOnboarding={restartOnboarding} />}
+        </main>
+      </div>
+    </>
   );
 }
 
@@ -41,11 +56,11 @@ function NavButton({ label, active, onClick }: { label: string; active: boolean;
   return (
     <button
       onClick={onClick}
-
+      title={`Ga naar ${label}`}
       className={`block w-full text-left px-2 py-1 rounded transition-transform duration-200 ${active ? 'bg-blue-600 text-white scale-105' : 'hover:bg-gray-700 hover:scale-105'}`}
-
     >
       {label}
     </button>
   );
 }
+

--- a/src/CreateNoteModal.tsx
+++ b/src/CreateNoteModal.tsx
@@ -87,23 +87,36 @@ export default function CreateNoteModal(
           <input
             className="px-3 py-2 rounded-lg bg-white/10 border border-white/15"
             placeholder="Titel"
+            aria-label="titel"
             value={title}
             onChange={(e) => setTitle(e.target.value)}
+            autoFocus
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && !e.shiftKey) {
+                e.preventDefault();
+                if (title.trim()) submit();
+              }
+            }}
           />
           <textarea
             className="px-3 py-2 rounded-lg bg-white/10 border border-white/15"
             placeholder="Inhoud"
+            aria-label="inhoud"
             rows={4}
             value={content}
             onChange={(e) => setContent(e.target.value)}
           />
 
-          <input
-            type="datetime-local"
-            className="px-3 py-2 rounded-lg bg-white/10 border border-white/15"
-            value={scheduled}
-            onChange={(e) => setScheduled(e.target.value)}
-          />
+          <div>
+            <input
+              type="datetime-local"
+              className="px-3 py-2 rounded-lg bg-white/10 border border-white/15 w-full"
+              value={scheduled}
+              onChange={(e) => setScheduled(e.target.value)}
+              aria-label="geplande datum"
+            />
+            <p className="text-xs text-slate-400 mt-1">Laat leeg om geen herinnering te zetten.</p>
+          </div>
 
           <div className="flex justify-end gap-2 mt-2">
             <button onClick={onClose} className="px-3 py-2 rounded-lg bg-white/10 border border-white/15">

--- a/src/HelpPage.tsx
+++ b/src/HelpPage.tsx
@@ -16,11 +16,16 @@ export default function HelpPage({ onRestartOnboarding }: { onRestartOnboarding:
         <p className="text-slate-300 mb-4">
           Orden je taken volgens de Eisenhower-matrix. Focus op de quadranten die echt impact hebben.
         </p>
+        <h2 className="text-xl font-semibold mt-6 mb-2">Missie & Waarden</h2>
+        <p className="text-slate-300 mb-4">
+          Bepaal je richting door je persoonlijke missie en kernwaarden in te vullen in de zijbalk.
+        </p>
 
         <div className="flex flex-col items-start gap-4">
           <button
             onClick={onRestartOnboarding}
             className="px-4 py-2 rounded-xl bg-teal-500/20 hover:bg-teal-500/30 border border-teal-300/30"
+            title="Start de rondleiding opnieuw"
           >
             Onboarding opnieuw starten
           </button>

--- a/src/Onboarding.tsx
+++ b/src/Onboarding.tsx
@@ -14,6 +14,10 @@ export default function Onboarding({ onFinish }: { onFinish: () => void }) {
     {
       title: 'Task matrix',
       body: 'Plan je dag met de Eisenhower-matrix en houd focus op wat er echt toe doet.'
+    },
+    {
+      title: 'Hulp nodig?',
+      body: 'Je kan deze rondleiding later opnieuw starten via de Help-pagina.'
     }
   ];
   const [index, setIndex] = useState(0);

--- a/src/Planner.tsx
+++ b/src/Planner.tsx
@@ -1,52 +1,108 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import type React from 'react';
 
-import { FiPlus } from 'react-icons/fi';
+import { FiPlus, FiChevronLeft, FiChevronRight } from 'react-icons/fi';
 import CreateTaskModal from './CreateTaskModal';
 import CreateNoteModal from './CreateNoteModal';
 
 
 const cls = (...xs: Array<string | false | undefined>) => xs.filter(Boolean).join(' ');
 
-function DayView({ onSelect }: { onSelect: (date: Date, e: React.MouseEvent) => void }) {
+interface PlannerEvent {
+  id: string | number;
+  type: 'task' | 'note';
+  title: string;
+  date: string; // YYYY-MM-DD
+  time?: string; // HH:MM
+}
+
+function DayView({
+  current,
+  events,
+  onQuickAdd,
+  onMenu,
+}: {
+  current: Date;
+  events: PlannerEvent[];
+  onQuickAdd: (date: Date) => void;
+  onMenu: (date: Date, e: React.MouseEvent) => void;
+}) {
   const hours = Array.from({ length: 17 }, (_, i) => i + 6); // 06:00-22:00
-  const today = new Date();
+  const currentIso = current.toISOString().slice(0, 10);
 
   return (
     <div className="grid grid-cols-[60px_1fr] gap-x-4 text-sm">
-      {hours.map((h) => (
-        <div key={h} className="contents">
-          <div className="text-right pr-2 text-slate-400">{String(h).padStart(2, '0')}:00</div>
+      {hours.map((h) => {
+        const evs = events.filter(
+          (ev) =>
+            ev.date === currentIso &&
+            ev.time &&
+            Number(ev.time.slice(0, 2)) === h
+        );
+        return (
+          <div key={h} className="contents">
+            <div className="text-right pr-2 text-slate-400">{String(h).padStart(2, '0')}:00</div>
 
-          <div
-            className="border-b border-slate-700 h-12 cursor-pointer"
-            onClick={(e) =>
-              onSelect(
-                new Date(
-                  today.getFullYear(),
-                  today.getMonth(),
-                  today.getDate(),
-                  h
-                ),
-                e
-              )
-            }
-          />
+            <div
+              className="border-b border-slate-700 h-12 cursor-pointer relative"
+              onClick={() =>
+                onQuickAdd(
+                  new Date(
+                    current.getFullYear(),
+                    current.getMonth(),
+                    current.getDate(),
+                    h
+                  )
+                )
+              }
+              onContextMenu={(e) => {
+                e.preventDefault();
+                onMenu(
+                  new Date(
+                    current.getFullYear(),
+                    current.getMonth(),
+                    current.getDate(),
+                    h
+                  ),
+                  e
+                );
+              }}
+            >
+              {evs.map((ev) => (
+                <div
+                  key={ev.id}
+                  className="absolute inset-0 m-1 rounded bg-teal-500/30 text-xs p-1 overflow-hidden"
+                >
+                  {ev.title}
+                </div>
+              ))}
+            </div>
 
-        </div>
-      ))}
+          </div>
+        );
+      })}
     </div>
   );
 }
 
 
-function WeekView({ onSelect }: { onSelect: (date: Date, e: React.MouseEvent) => void }) {
+function WeekView({
+  current,
+  events,
+  onQuickAdd,
+  onMenu,
+}: {
+  current: Date;
+  events: PlannerEvent[];
+  onQuickAdd: (date: Date) => void;
+  onMenu: (date: Date, e: React.MouseEvent) => void;
+}) {
   const days = ['Ma', 'Di', 'Wo', 'Do', 'Vr', 'Za', 'Zo'];
   const hours = Array.from({ length: 17 }, (_, i) => i + 6);
   const now = new Date();
-  const monday = new Date(now);
-  monday.setDate(now.getDate() - ((now.getDay() + 6) % 7));
+  const monday = new Date(current);
+  monday.setDate(current.getDate() - ((current.getDay() + 6) % 7));
 
   return (
     <div className="grid grid-cols-[60px_repeat(7,1fr)] text-sm">
@@ -76,16 +132,36 @@ function WeekView({ onSelect }: { onSelect: (date: Date, e: React.MouseEvent) =>
             {String(h).padStart(2, '0')}:00
           </div>
 
-          {days.map((_, i) => {
+        {days.map((_, i) => {
             const d = new Date(monday);
             d.setDate(monday.getDate() + i);
             d.setHours(h, 0, 0, 0);
+            const iso = d.toISOString().slice(0, 10);
+            const evs = events.filter(
+              (ev) =>
+                ev.date === iso &&
+                ev.time &&
+                Number(ev.time.slice(0, 2)) === h
+            );
             return (
               <div
                 key={i}
-                className="border-l border-t border-slate-700 h-12 cursor-pointer"
-                onClick={(e) => onSelect(d, e)}
-              />
+                className="border-l border-t border-slate-700 h-12 cursor-pointer relative"
+                onClick={() => onQuickAdd(new Date(d))}
+                onContextMenu={(e) => {
+                  e.preventDefault();
+                  onMenu(new Date(d), e);
+                }}
+              >
+                {evs.map((ev) => (
+                  <div
+                    key={ev.id}
+                    className="absolute inset-0 m-1 rounded bg-teal-500/30 text-xs p-1 overflow-hidden"
+                  >
+                    {ev.title}
+                  </div>
+                ))}
+              </div>
             );
           })}
 
@@ -96,11 +172,20 @@ function WeekView({ onSelect }: { onSelect: (date: Date, e: React.MouseEvent) =>
 }
 
 
-function MonthView({ onSelect }: { onSelect: (date: Date, e: React.MouseEvent) => void }) {
-
+function MonthView({
+  current,
+  events,
+  onQuickAdd,
+  onMenu,
+}: {
+  current: Date;
+  events: PlannerEvent[];
+  onQuickAdd: (date: Date) => void;
+  onMenu: (date: Date, e: React.MouseEvent) => void;
+}) {
   const now = new Date();
-  const year = now.getFullYear();
-  const month = now.getMonth();
+  const year = current.getFullYear();
+  const month = current.getMonth();
   const first = new Date(year, month, 1);
   const start = (first.getDay() + 6) % 7; // maandag = 0
   const cells = Array.from({ length: 42 }, (_, i) => {
@@ -120,6 +205,8 @@ function MonthView({ onSelect }: { onSelect: (date: Date, e: React.MouseEvent) =
           c.date.getDate() === now.getDate() &&
           c.date.getMonth() === now.getMonth() &&
           c.date.getFullYear() === now.getFullYear();
+        const iso = c.date.toISOString().slice(0, 10);
+        const evs = events.filter((ev) => ev.date === iso);
         return (
           <div
             key={i}
@@ -128,9 +215,21 @@ function MonthView({ onSelect }: { onSelect: (date: Date, e: React.MouseEvent) =
               c.current ? '' : 'bg-white/5 text-slate-500',
               isToday && 'bg-teal-500/20 text-teal-200'
             )}
-            onClick={(e) => onSelect(new Date(c.date), e)}
+            onClick={() => onQuickAdd(new Date(c.date))}
+            onContextMenu={(e) => {
+              e.preventDefault();
+              onMenu(new Date(c.date), e);
+            }}
           >
             <div className="text-right text-xs">{c.date.getDate()}</div>
+            {evs.slice(0, 3).map((ev) => (
+              <div
+                key={ev.id}
+                className="mt-1 text-xs truncate rounded bg-teal-500/30 px-1"
+              >
+                {ev.title}
+              </div>
+            ))}
           </div>
         );
       })}
@@ -140,21 +239,119 @@ function MonthView({ onSelect }: { onSelect: (date: Date, e: React.MouseEvent) =
 
 export default function Planner() {
   const [view, setView] = useState<'day' | 'week' | 'month'>('day');
+  const [current, setCurrent] = useState(new Date());
 
   const [taskModal, setTaskModal] = useState(false);
   const [noteModal, setNoteModal] = useState(false);
   const [selectedDate, setSelectedDate] = useState<Date | null>(null);
   const [menu, setMenu] = useState<{ date: Date; x: number; y: number } | null>(null);
+  const [events, setEvents] = useState<PlannerEvent[]>(() => {
+    try {
+      const raw = localStorage.getItem('hf.events');
+      return raw ? (JSON.parse(raw) as PlannerEvent[]) : [];
+    } catch {
+      return [];
+    }
+  });
 
-  function handleSelect(date: Date, e: React.MouseEvent) {
+  useEffect(() => {
+    try {
+      localStorage.setItem('hf.events', JSON.stringify(events));
+    } catch {
+      /* ignore */
+    }
+  }, [events]);
+
+  function addEvent(ev: PlannerEvent) {
+    setEvents((prev) => [...prev, ev]);
+  }
+
+  function handleQuickAdd(date: Date) {
+    setSelectedDate(date);
+    setNoteModal(true);
+  }
+
+  function handleMenu(date: Date, e: React.MouseEvent) {
     setMenu({ date, x: e.clientX, y: e.clientY });
   }
 
+  function prev() {
+    const d = new Date(current);
+    if (view === 'day') d.setDate(d.getDate() - 1);
+    if (view === 'week') d.setDate(d.getDate() - 7);
+    if (view === 'month') d.setMonth(d.getMonth() - 1);
+    setCurrent(d);
+  }
+
+  function next() {
+    const d = new Date(current);
+    if (view === 'day') d.setDate(d.getDate() + 1);
+    if (view === 'week') d.setDate(d.getDate() + 7);
+    if (view === 'month') d.setMonth(d.getMonth() + 1);
+    setCurrent(d);
+  }
+
+  function today() {
+    setCurrent(new Date());
+  }
+
+  let label = '';
+  if (view === 'day') {
+    label = current.toLocaleDateString('nl-BE', {
+      weekday: 'long',
+      day: 'numeric',
+      month: 'long',
+      year: 'numeric',
+    });
+  } else if (view === 'week') {
+    const monday = new Date(current);
+    monday.setDate(current.getDate() - ((current.getDay() + 6) % 7));
+    const sunday = new Date(monday);
+    sunday.setDate(monday.getDate() + 6);
+    label = `${monday.toLocaleDateString('nl-BE', { day: 'numeric', month: 'short' })} – ${sunday.toLocaleDateString('nl-BE', {
+      day: 'numeric',
+      month: 'short',
+      year: 'numeric',
+    })}`;
+  } else {
+    label = current.toLocaleDateString('nl-BE', {
+      month: 'long',
+      year: 'numeric',
+    });
+  }
 
   return (
-    <div className="p-8">
+    <div className="min-h-screen p-8 bg-gradient-to-b from-slate-950 via-slate-900 to-slate-800 text-slate-100">
       <section className="max-w-5xl mx-auto rounded-2xl backdrop-blur-xl bg-white/5 border border-white/10 p-8 shadow-lg">
-        <div className="mb-4 flex flex-wrap items-center justify-between gap-2">
+        <div className="mb-4 flex flex-wrap items-center justify-between gap-4">
+          <div className="flex items-center gap-2">
+            <button
+              className="p-2 rounded-lg bg-white/10 hover:bg-white/20"
+              onClick={prev}
+              title="Vorige periode"
+              aria-label="vorige periode"
+            >
+              <FiChevronLeft />
+            </button>
+            <button
+              className="px-3 py-2 rounded-lg bg-white/10 hover:bg-white/20 text-sm"
+              onClick={today}
+              title="Spring naar vandaag"
+              aria-label="ga naar vandaag"
+            >
+              Vandaag
+            </button>
+            <button
+              className="p-2 rounded-lg bg-white/10 hover:bg-white/20"
+              onClick={next}
+              title="Volgende periode"
+              aria-label="volgende periode"
+            >
+              <FiChevronRight />
+            </button>
+            <span className="ml-4 font-semibold capitalize">{label}</span>
+          </div>
+
           <div className="flex gap-2">
             <button
               className={cls(
@@ -162,6 +359,7 @@ export default function Planner() {
                 view === 'day' ? 'bg-white/20 text-teal-300' : 'bg-white/10 hover:bg-white/15'
               )}
               onClick={() => setView('day')}
+              title="Toon dagoverzicht"
             >
               Dag
             </button>
@@ -171,6 +369,7 @@ export default function Planner() {
                 view === 'week' ? 'bg-white/20 text-teal-300' : 'bg-white/10 hover:bg-white/15'
               )}
               onClick={() => setView('week')}
+              title="Toon weekoverzicht"
             >
               Week
             </button>
@@ -180,40 +379,60 @@ export default function Planner() {
                 view === 'month' ? 'bg-white/20 text-teal-300' : 'bg-white/10 hover:bg-white/15'
               )}
               onClick={() => setView('month')}
+              title="Toon maandoverzicht"
             >
               Maand
             </button>
           </div>
+
           <div className="flex gap-2">
             <button
               className="px-3 py-2 rounded-lg bg-teal-400/20 hover:bg-teal-400/30 border border-teal-300/30 text-teal-200 text-sm flex items-center gap-2"
-
               onClick={() => {
                 setSelectedDate(new Date());
                 setTaskModal(true);
               }}
-
+              title="Voeg een nieuwe taak toe"
             >
               <FiPlus /> Nieuwe taak
             </button>
             <button
               className="px-3 py-2 rounded-lg bg-teal-400/20 hover:bg-teal-400/30 border border-teal-300/30 text-teal-200 text-sm flex items-center gap-2"
-
               onClick={() => {
                 setSelectedDate(new Date());
                 setNoteModal(true);
               }}
-
+              title="Maak een nieuwe notitie"
             >
               <FiPlus /> Nieuwe notitie
             </button>
           </div>
-
         </div>
         <div className="overflow-auto">
-          {view === 'day' && <DayView onSelect={handleSelect} />}
-          {view === 'week' && <WeekView onSelect={handleSelect} />}
-          {view === 'month' && <MonthView onSelect={handleSelect} />}
+          {view === 'day' && (
+            <DayView
+              current={current}
+              events={events}
+              onQuickAdd={handleQuickAdd}
+              onMenu={handleMenu}
+            />
+          )}
+          {view === 'week' && (
+            <WeekView
+              current={current}
+              events={events}
+              onQuickAdd={handleQuickAdd}
+              onMenu={handleMenu}
+            />
+          )}
+          {view === 'month' && (
+            <MonthView
+              current={current}
+              events={events}
+              onQuickAdd={handleQuickAdd}
+              onMenu={handleMenu}
+            />
+          )}
         </div>
       </section>
       {menu && (
@@ -249,16 +468,39 @@ export default function Planner() {
       <CreateTaskModal
         open={taskModal}
         onClose={() => setTaskModal(false)}
-        onCreated={() => {}}
+        onCreated={(t) => {
+          addEvent({
+            id: t.id,
+            type: 'task',
+            title: t.title,
+            date:
+              t.dueAt?.slice(0, 10) ||
+              (selectedDate
+                ? selectedDate.toISOString().slice(0, 10)
+                : new Date().toISOString().slice(0, 10)),
+            time: t.dueAt?.slice(11, 16),
+          });
+        }}
         initialDate={selectedDate}
       />
       <CreateNoteModal
         open={noteModal}
         onClose={() => setNoteModal(false)}
-        onCreated={() => {}}
+        onCreated={(n) => {
+          addEvent({
+            id: n.id,
+            type: 'note',
+            title: n.title,
+            date:
+              n.scheduledAt?.slice(0, 10) ||
+              (selectedDate
+                ? selectedDate.toISOString().slice(0, 10)
+                : new Date().toISOString().slice(0, 10)),
+            time: n.scheduledAt?.slice(11, 16),
+          });
+        }}
         initialDate={selectedDate}
       />
-
     </div>
   );
 }

--- a/src/components/MissionValues.tsx
+++ b/src/components/MissionValues.tsx
@@ -13,7 +13,6 @@ export default function MissionValues() {
   };
 
   return (
-
     <div className="space-y-2" aria-label="missie en waarden">
       <div className="flex justify-between items-center">
         <h2 className="text-lg font-semibold">Missie & Waarden</h2>
@@ -21,47 +20,51 @@ export default function MissionValues() {
           className="text-sm text-blue-400 underline"
           onClick={() => setEditing((e) => !e)}
           aria-label={editing ? 'toon voorbeeld' : 'bewerk missie en waarden'}
+          title={editing ? 'Toon voorbeeld' : 'Bewerk missie en waarden'}
         >
           {editing ? 'Voorbeeld' : 'Bewerk'}
-
         </button>
       </div>
+      <p className="text-sm text-slate-300">Formuleer je persoonlijke missie en de waarden die je richting geven.</p>
       {editing ? (
         <div className="space-y-2">
-          <textarea
-            className="w-full h-40 p-2 border rounded bg-gray-800"
-
-            value={user.mission}
-            onChange={(e) =>
-              setState((s) => ({ ...s, user: { ...s.user, mission: e.target.value } }))
-            }
-
-            aria-label="missie"
-            placeholder="Jouw missie in markdown"
-          />
-          <textarea
-            className="w-full h-40 p-2 border rounded bg-gray-800"
-
-            value={user.values}
-            onChange={(e) =>
-              setState((s) => ({ ...s, user: { ...s.user, values: e.target.value } }))
-            }
-
-            aria-label="kernwaarden"
-            placeholder="Jouw kernwaarden in markdown"
-          />
+          <div>
+            <textarea
+              className="w-full h-40 p-2 border rounded bg-gray-800"
+              value={user.mission}
+              onChange={(e) =>
+                setState((s) => ({ ...s, user: { ...s.user, mission: e.target.value } }))
+              }
+              aria-label="missie"
+              placeholder="Jouw missie in markdown"
+            />
+            <p className="text-xs text-slate-400 mt-1">Tip: beschrijf in 1-2 zinnen wat je drijft.</p>
+          </div>
+          <div>
+            <textarea
+              className="w-full h-40 p-2 border rounded bg-gray-800"
+              value={user.values}
+              onChange={(e) =>
+                setState((s) => ({ ...s, user: { ...s.user, values: e.target.value } }))
+              }
+              aria-label="kernwaarden"
+              placeholder="Jouw kernwaarden in markdown"
+            />
+            <p className="text-xs text-slate-400 mt-1">Som je kernwaarden op, gescheiden door nieuwe regels.</p>
+          </div>
           <button className="bg-blue-600 text-white px-2 py-1 rounded" onClick={save}>
             Bewaar
-
           </button>
         </div>
       ) : (
-        <div className="prose prose-sm max-w-none">
-
-          <ReactMarkdown remarkPlugins={[remarkGfm]}>{`## Missie\n${user.mission}`}</ReactMarkdown>
-          <ReactMarkdown remarkPlugins={[remarkGfm]}>{`## Waarden\n${user.values}`}</ReactMarkdown>
-
-        </div>
+        !user.mission && !user.values ? (
+          <p className="text-slate-400 text-sm">Nog niets ingevuld. Klik op 'Bewerk' om te starten.</p>
+        ) : (
+          <div className="prose prose-sm max-w-none">
+            <ReactMarkdown remarkPlugins={[remarkGfm]}>{`## Missie\n${user.mission}`}</ReactMarkdown>
+            <ReactMarkdown remarkPlugins={[remarkGfm]}>{`## Waarden\n${user.values}`}</ReactMarkdown>
+          </div>
+        )
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- integrate restartable onboarding with help page navigation
- improve mission & values section with guidance and empty state messaging
- add tooltips and hints for planner navigation and note scheduling

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b4ba9acf3483328bab87d6bea244e3