### PR TITLE
style: refine layout with glass cards

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,8 +25,8 @@ export default function App() {
   return (
     <>
       {showOnboarding && <Onboarding onFinish={() => setShowOnboarding(false)} />}
-      <div className="flex h-screen bg-gradient-to-br from-gray-900 via-blue-900 to-gray-900 text-gray-100">
-        <aside className="w-64 border-r border-gray-700 p-4 overflow-y-auto backdrop-blur" aria-label="zijbalk">
+        <div className="flex h-screen bg-gradient-to-br from-slate-950 via-slate-900 to-slate-800 text-gray-100">
+          <aside className="w-64 border-r border-white/10 bg-white/5 p-4 overflow-y-auto backdrop-blur-xl" aria-label="zijbalk">
           <MissionValues />
           <nav className="mt-4 space-y-1">
             <NavButton label="Weekplanner" active={page === 'planner'} onClick={() => setPage('planner')} />

--- a/src/HomePage.tsx
+++ b/src/HomePage.tsx
@@ -1,10 +1,11 @@
 import { FiCalendar, FiFileText, FiArrowRight, FiGrid } from 'react-icons/fi';
 import { Sparkles } from 'lucide-react';
+import GlassCard from './components/GlassCard';
 
 export default function HomePage({ onSelect }: { onSelect: (view: 'tasks' | 'planner' | 'notes') => void }) {
   return (
     <div className="p-8">
-      <section className="max-w-3xl mx-auto rounded-2xl backdrop-blur-xl bg-white/5 border border-white/10 p-8 shadow-lg">
+      <GlassCard className="max-w-3xl mx-auto p-8">
         <h1 className="text-2xl font-semibold mb-4">Welkom terug!</h1>
         <p className="text-slate-300 mb-6 flex items-center gap-2">
           <Sparkles className="text-teal-300" size={16} /> Klaar om productief te zijn?
@@ -32,7 +33,7 @@ export default function HomePage({ onSelect }: { onSelect: (view: 'tasks' | 'pla
             <FiArrowRight className="opacity-0 group-hover:opacity-100 group-hover:translate-x-1 transition" />
           </button>
         </div>
-      </section>
+      </GlassCard>
     </div>
   );
 }

--- a/src/TeslaLayout.tsx
+++ b/src/TeslaLayout.tsx
@@ -15,6 +15,7 @@ import App from './App';
 import HomePage from './HomePage';
 import Onboarding from './Onboarding';
 import HelpPage from './HelpPage';
+import GlassCard from './components/GlassCard';
 
 const cls = (...xs: Array<string | false | undefined>) => xs.filter(Boolean).join(' ');
 
@@ -30,9 +31,9 @@ export default function TeslaLayout() {
   }
 
   return (
-    <div className="flex h-screen text-slate-100">
-      {/* Navigation bar */}
-      <nav className="w-20 flex flex-col items-center py-6 bg-black/80 backdrop-blur-xl border-r border-white/10">
+      <div className="flex h-screen text-slate-100">
+        {/* Navigation bar */}
+        <nav className="w-20 flex flex-col items-center py-6 bg-black/60 backdrop-blur-xl border-r border-white/10">
         <div className="mb-8 text-red-500 text-2xl font-bold">⚡</div>
 
         <ul className="flex-1 flex flex-col gap-6 list-none">
@@ -108,16 +109,8 @@ export default function TeslaLayout() {
         </button>
       </nav>
 
-      {/* Main content */}
-      <main className="flex-1 relative overflow-auto bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900">
-        <div
-          className="absolute inset-0 -z-10 opacity-20"
-          style={{
-            backgroundImage:
-              'radial-gradient(circle at 1px 1px, rgba(255,255,255,.25) 1px, transparent 1px)',
-            backgroundSize: '24px 24px'
-          }}
-        />
+        {/* Main content */}
+        <main className="flex-1 relative overflow-auto bg-gradient-to-br from-slate-950 via-slate-900 to-slate-800">
         {active === 'home' && <HomePage onSelect={setActive} />}
         {active === 'tasks' && <TaskMatrix />}
         {active === 'planner' && <Planner />}
@@ -132,14 +125,14 @@ export default function TeslaLayout() {
           />
         )}
 
-        {active === 'profile' && (
-          <div className="p-8">
-            <section className="max-w-3xl mx-auto rounded-2xl backdrop-blur-xl bg-white/5 border border-white/10 p-8 shadow-lg">
-              <h1 className="text-2xl font-semibold mb-4">Profiel</h1>
-              <p className="text-slate-300">Profielinformatie komt hier.</p>
-            </section>
-          </div>
-        )}
+          {active === 'profile' && (
+            <div className="p-8">
+              <GlassCard className="max-w-3xl mx-auto p-8">
+                <h1 className="text-2xl font-semibold mb-4">Profiel</h1>
+                <p className="text-slate-300">Profielinformatie komt hier.</p>
+              </GlassCard>
+            </div>
+          )}
       </main>
       {showOnboarding && <Onboarding onFinish={() => setShowOnboarding(false)} />}
     </div>

--- a/src/components/GlassCard.tsx
+++ b/src/components/GlassCard.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from 'react';
+
+export default function GlassCard({ children, className = '' }: { children: ReactNode; className?: string }) {
+  return (
+    <div className={`rounded-2xl bg-white/5 backdrop-blur-xl border border-white/10 shadow-lg ${className}`}>
+      {children}
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -5,13 +5,8 @@
 html, body, #root { height: 100%; }
 
 body {
-  /* futuristische Tesla-achtige look */
-  font-family: 'Orbitron', sans-serif;
-  background:
-    radial-gradient(ellipse at top left, rgba(56,189,248,0.12), transparent 60%),
-    radial-gradient(ellipse at bottom right, rgba(56,189,248,0.05), transparent 60%),
-    radial-gradient(circle at 1px 1px, rgba(255,255,255,.15) 1px, transparent 1px) 0 0/24px 24px,
-    linear-gradient(to bottom right, #0a0a0f, #001f3f);
+  font-family: system-ui, sans-serif;
+  background: linear-gradient(to bottom right, #020617, #0f172a, #1e293b);
   color: #e5e7eb; /* text-slate-200 */
   margin: 0;
 }


### PR DESCRIPTION
## Summary
- modernize global look with system font and minimal dark gradient
- add reusable GlassCard component and apply to home and profile sections
- soften navigation and content backgrounds for a cleaner 2025 feel

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b560dd1748833281e1d9691b3bdb5e