### PR TITLE
feat: add note editor with autosave

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import MissionValues from './components/MissionValues';
 import RolesGoals from './components/RolesGoals';
 import WeeklyPlanner from './components/WeeklyPlanner';
 import DailyPage from './components/DailyPage';
+import Agenda from './components/Agenda';
 import Notes from './components/Notes';
 import SharpenSaw from './components/SharpenSaw';
 import Reflection from './components/Reflection';
@@ -11,7 +12,14 @@ import Onboarding from './Onboarding';
 
 export default function App() {
   const [page, setPage] = useState<
-    'planner' | 'daily' | 'compass' | 'notes' | 'renewal' | 'reflection' | 'help'
+    | 'planner'
+    | 'agenda'
+    | 'daily'
+    | 'compass'
+    | 'notes'
+    | 'renewal'
+    | 'reflection'
+    | 'help'
   >('planner');
   const [showOnboarding, setShowOnboarding] = useState(
     () => !localStorage.getItem('hf.onboarded')
@@ -30,6 +38,7 @@ export default function App() {
           <MissionValues />
           <nav className="mt-4 space-y-1">
             <NavButton label="Weekplanner" active={page === 'planner'} onClick={() => setPage('planner')} />
+            <NavButton label="Agenda" active={page === 'agenda'} onClick={() => setPage('agenda')} />
             <NavButton label="Dag" active={page === 'daily'} onClick={() => setPage('daily')} />
             <NavButton label="Weekkompas" active={page === 'compass'} onClick={() => setPage('compass')} />
             <NavButton label="Notities" active={page === 'notes'} onClick={() => setPage('notes')} />
@@ -40,6 +49,7 @@ export default function App() {
         </aside>
         <main className="flex-1 overflow-y-auto p-4 animate-fade-in" aria-label="hoofdinhoud">
           {page === 'planner' && <WeeklyPlanner />}
+          {page === 'agenda' && <Agenda />}
           {page === 'daily' && <DailyPage />}
           {page === 'compass' && <RolesGoals />}
           {page === 'notes' && <Notes />}

--- a/src/components/Agenda.tsx
+++ b/src/components/Agenda.tsx
@@ -1,0 +1,45 @@
+import { useMemo } from 'react';
+import { usePlanner } from '../PlannerContext';
+import GlassCard from './GlassCard';
+import type { Task } from '../models';
+
+export default function Agenda() {
+  const { state } = usePlanner();
+  const groups = useMemo(() => {
+    const sorted = [...state.tasks].sort((a, b) =>
+      a.day.localeCompare(b.day) || a.time.localeCompare(b.time)
+    );
+    return sorted.reduce<Record<string, Task[]>>((acc, t) => {
+      acc[t.day] = acc[t.day] ? [...acc[t.day], t] : [t];
+      return acc;
+    }, {});
+  }, [state.tasks]);
+
+  return (
+    <div className="space-y-4" aria-label="agenda">
+      <h2 className="text-xl font-semibold">Agenda</h2>
+      <ul className="space-y-4">
+        {Object.entries(groups).map(([date, tasks]) => (
+          <li key={date}>
+            <GlassCard className="p-2">
+              <h3 className="font-medium mb-2">
+                {new Date(date).toLocaleDateString('nl-BE', {
+                  weekday: 'long',
+                  day: 'numeric',
+                  month: 'long',
+                })}
+              </h3>
+              <ul className="space-y-1">
+                {tasks.map((t) => (
+                  <li key={t.id}>
+                    {t.time} {t.title}
+                  </li>
+                ))}
+              </ul>
+            </GlassCard>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/DailyPage.tsx
+++ b/src/components/DailyPage.tsx
@@ -7,31 +7,23 @@ import type { Note, Task } from '../models';
 import { analyzeNote } from '../ai';
 import GlassCard from './GlassCard';
 
-const dayLabel = ['Zo','Ma','Di','Wo','Do','Vr','Za'];
-
-
-function todayName() {
-  return dayLabel[new Date().getDay()];
-}
-
 export default function DailyPage() {
   const { state, setState } = usePlanner();
-  const day = todayName();
-  const tasks = state.tasks.filter((t) => t.day === day);
+  const today = new Date().toISOString().split('T')[0];
+  const tasks = state.tasks.filter((t) => t.day === today);
   const priorities = tasks.filter((t) => t.type === 'rock').slice(0, 3);
   const [note, setNote] = useState('');
 
 
   const addNote = async () => {
     if (!note.trim()) return;
-    const today = new Date().toISOString().split('T')[0];
     const newNote: Note = {
       id: Date.now().toString(),
       content: note,
       summary: '',
       date: today,
 
-      tags: ['dagelijks', day],
+      tags: ['dagelijks', today],
       linkedWeek: undefined,
       urgent: false,
       important: false,
@@ -41,12 +33,11 @@ export default function DailyPage() {
     analyzeNote(note).then(({ summary, tasks }) => {
       setState((s) => {
         const notes = s.notes.map((n) => (n.id === newNote.id ? { ...n, summary } : n));
-        const dayNames = ['Zo','Ma','Di','Wo','Do','Vr','Za'];
         const newTasks: Task[] = tasks.map((t) => ({
           id: `${Date.now()}-${Math.random()}`,
           title: t.title,
           type: 'sand',
-          day: dayNames[new Date(t.date || today).getDay()],
+          day: t.date ?? today,
           time: '09:00',
           linkedGoalId: undefined,
         }));

--- a/src/components/NoteEditor.tsx
+++ b/src/components/NoteEditor.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useState } from 'react';
+import { Save } from 'lucide-react';
+import { createNote, updateNote } from '../services/api';
+import { aiSummarize } from '../services/ai';
+import type { Note, HabitId, Quadrant } from '../types';
+
+export default function NoteEditor({ onCreated }: { onCreated: (n: Note) => void }) {
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+  const [summary, setSummary] = useState<string | null>(null);
+
+  // Load draft from localStorage
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem('hf.draft.note');
+      if (raw) {
+        const d = JSON.parse(raw) as { title?: string; content?: string };
+        setTitle(d.title ?? '');
+        setContent(d.content ?? '');
+      }
+    } catch {
+      /* ignore */
+    }
+  }, []);
+
+  // Autosave draft
+  useEffect(() => {
+    const id = setTimeout(() => {
+      try {
+        localStorage.setItem(
+          'hf.draft.note',
+          JSON.stringify({ title, content })
+        );
+      } catch {
+        /* ignore */
+      }
+    }, 500);
+    return () => clearTimeout(id);
+  }, [title, content]);
+
+  async function save() {
+    if (!title.trim() && !content.trim()) return;
+    const created = await createNote({ title: title.trim() || 'Untitled', content, tags: [] });
+    try {
+      const ai = await aiSummarize(created.id);
+      const patched = await updateNote(created.id, {
+        habit: (ai.habit ?? undefined) as HabitId | undefined,
+        quadrant: (ai.quadrant ?? undefined) as Quadrant | undefined,
+        tags: ai.suggestedTags ?? [],
+      });
+      onCreated(patched);
+      setSummary(ai.summary);
+    } catch {
+      onCreated(created);
+    }
+    setTitle('');
+    setContent('');
+    localStorage.removeItem('hf.draft.note');
+  }
+
+  return (
+    <div className="space-y-2" aria-label="note editor">
+      <input
+        className="w-full p-2 rounded bg-transparent border border-white/10"
+        placeholder="Titel"
+        aria-label="titel"
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+      />
+      <textarea
+        className="w-full h-32 p-2 rounded bg-transparent border border-white/10"
+        placeholder="Inhoud in markdown"
+        aria-label="inhoud"
+        value={content}
+        onChange={(e) => setContent(e.target.value)}
+      />
+      <button
+        onClick={save}
+        className="flex items-center gap-1 px-3 py-2 rounded-lg bg-teal-400/20 hover:bg-teal-400/30 border border-teal-300/30 text-teal-200"
+        aria-label="bewaar notitie"
+      >
+        <Save className="w-4 h-4" />
+        Bewaar
+      </button>
+      {summary && (
+        <p className="text-sm text-teal-200" aria-live="polite">
+          Samenvatting: {summary}
+        </p>
+      )}
+    </div>
+  );
+}
+

--- a/src/components/WeeklyPlanner.tsx
+++ b/src/components/WeeklyPlanner.tsx
@@ -5,16 +5,24 @@ import { usePlanner } from '../PlannerContext';
 import type { Task } from '../models';
 import GlassCard from './GlassCard';
 
-const days = ['Ma', 'Di', 'Wo', 'Do', 'Vr', 'Za', 'Zo'];
+const labels = ['Ma', 'Di', 'Wo', 'Do', 'Vr', 'Za', 'Zo'];
 
+function weekDays() {
+  const monday = new Date();
+  monday.setDate(monday.getDate() - ((monday.getDay() + 6) % 7));
+  return labels.map((label, i) => {
+    const d = new Date(monday);
+    d.setDate(monday.getDate() + i);
+    return { label, date: d.toISOString().split('T')[0] };
+  });
+}
 
 export default function WeeklyPlanner() {
   const { state, setState } = usePlanner();
   const [title, setTitle] = useState('');
   const [type, setType] = useState<'rock' | 'sand'>('rock');
-
-  const [day, setDay] = useState('Ma');
-
+  const week = weekDays();
+  const [day, setDay] = useState(week[0].date);
   const [time, setTime] = useState('09:00');
 
   const addTask = () => {
@@ -42,13 +50,14 @@ export default function WeeklyPlanner() {
     });
   };
 
-  const tasksByDay = (day: string) =>
+  const tasksByDay = (date: string) =>
     state.tasks
-      .filter((t) => t.day === day)
-      .sort((a, b) => (a.type === b.type ? a.time.localeCompare(b.time) : a.type === 'rock' ? -1 : 1));
+      .filter((t) => t.day === date)
+      .sort((a, b) =>
+        a.type === b.type ? a.time.localeCompare(b.time) : a.type === 'rock' ? -1 : 1
+      );
 
   return (
-
     <div aria-label="weekplanner" className="space-y-4">
       <h2 className="text-xl font-semibold">Weekplanner</h2>
 
@@ -75,9 +84,9 @@ export default function WeeklyPlanner() {
           onChange={(e) => setDay(e.target.value)}
           aria-label="taak dag"
         >
-          {days.map((d) => (
-            <option key={d} value={d}>
-              {d}
+          {week.map((d) => (
+            <option key={d.date} value={d.date}>
+              {d.label}
             </option>
           ))}
         </select>
@@ -94,25 +103,27 @@ export default function WeeklyPlanner() {
       </GlassCard>
       <DragDropContext onDragEnd={onDragEnd}>
         <div className="grid grid-cols-7 gap-2">
-          {days.map((d) => (
-            <Droppable droppableId={d} key={d}>
+          {week.map((d) => (
+            <Droppable droppableId={d.date} key={d.date}>
               {(provided) => (
                 <GlassCard
                   ref={provided.innerRef}
                   {...provided.droppableProps}
                   className="min-h-[200px] p-1"
                 >
-                  <h3 className="text-center font-medium mb-1">{d}</h3>
-                  {tasksByDay(d).map((t, idx) => (
+                  <h3 className="text-center font-medium mb-1">
+                    {d.label} {new Date(d.date).getDate()}
+                  </h3>
+                  {tasksByDay(d.date).map((t, idx) => (
                     <Draggable key={t.id} draggableId={t.id} index={idx}>
                       {(drag) => (
                         <div
                           ref={drag.innerRef}
                           {...drag.draggableProps}
                           {...drag.dragHandleProps}
-
-                          className={`p-1 mb-1 rounded text-sm text-white transition-transform duration-200 ${t.type === 'rock' ? 'bg-blue-600' : 'bg-gray-500'} hover:scale-105`}
-
+                          className={`p-1 mb-1 rounded text-sm text-white transition-transform duration-200 ${
+                            t.type === 'rock' ? 'bg-blue-600' : 'bg-gray-500'
+                          } hover:scale-105`}
                         >
                           {t.time} {t.title}
                         </div>


### PR DESCRIPTION
## Summary
- build note editor component with localStorage draft and AI summarization
- refactor notes page to fetch and persist notes via API with search and delete
- add agenda view syncing week and day planners with ISO dates

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b58cebae1883328f3d87733369c163